### PR TITLE
remove doctrine alias mapping

### DIFF
--- a/DukecityCommandSchedulerBundle.php
+++ b/DukecityCommandSchedulerBundle.php
@@ -24,7 +24,6 @@ class DukecityCommandSchedulerBundle extends Bundle
             $directories = [realpath(__DIR__.'/Entity')];
             $managerParameters = [];
             $enabledParameter = false;
-            $aliasMap = ['CommandSchedulerBundle' => 'Dukecity\CommandSchedulerBundle\Entity'];
 
             $driver = new Definition('Doctrine\ORM\Mapping\Driver\AttributeDriver', [$directories]);
 
@@ -34,7 +33,6 @@ class DukecityCommandSchedulerBundle extends Bundle
                     $namespaces,
                     $managerParameters,
                     $enabledParameter,
-                    $aliasMap
                 )
             );
 


### PR DESCRIPTION
Fixes deprecated usage of short name alias with doctrine/persistence:3.x

```
Doctrine\ORM\Exception\NotSupported : Context: Using short namespace alias "CommandSchedulerBundle" by calling Doctrine\ORM\Configuration::addEntityNamespace
Problem: Feature was deprecated in doctrine/persistence 2.x and is not supported by installed doctrine/persistence:3.x
```